### PR TITLE
Adds test for automatic clean URL redirects

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -57,6 +57,21 @@ var routes = [
   tests: [
     //["/person?name=fred", "/p/fred"]
   ]
+},
+
+{
+  route: [301, "/", "http://chloi.io"],
+  tests: [
+    ["/", "http://chloi.io"]
+  ]
+},
+
+{
+  route: [307, "/:title", "http://chloi.io/:title"],
+  tests: [
+    ["/office", "http://chloi.io/office"],
+    ["/contact", "http://chloi.io/contact"]
+  ]
 }
 ]
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -62,15 +62,17 @@ var routes = [
 {
   route: [301, "/", "http://chloi.io"],
   tests: [
-    ["/", "http://chloi.io"]
+    ["/", "http://chloi.io"],
+    ["/index.html", "http://chloi.io"]
   ]
 },
 
 {
   route: [307, "/:title", "http://chloi.io/:title"],
   tests: [
-    ["/office", "http://chloi.io/office"],
-    ["/contact", "http://chloi.io/contact"]
+    ["/office/", "http://chloi.io/office/"],
+    ["/contact", "http://chloi.io/contact/"],
+    ["/contact/index.html", "http://chloi.io/contact"]
   ]
 }
 ]


### PR DESCRIPTION
Adds initial, failing tests if we were to want Yonder to automatically support / assume clean URLs as part of the redirects.

For example, with this redirect setup:

```
301   /   http://kennethormandy.com
```

…should `/index.html` automatially redirect to `http://kennethormandy.com`?

I am not sure if this should be merged and the tests made to pass, just something to consider.
